### PR TITLE
feat: Add canceling job support

### DIFF
--- a/aide-de-camp-sqlite-bench/Cargo.toml
+++ b/aide-de-camp-sqlite-bench/Cargo.toml
@@ -13,4 +13,4 @@ aide-de-camp-sqlite = { path = "../aide-de-camp-sqlite", version = "0.1.0" }
 futures = "0.3.21"
 async-trait = "0.1.52"
 anyhow = "1.0.53"
-sqlx = {version = "0.5.13", default-features = false , features = ["sqlite", "macros", "chrono"]}
+sqlx = {version = "0.6.2", default-features = false , features = ["sqlite", "macros", "chrono"]}

--- a/aide-de-camp-sqlite/Cargo.toml
+++ b/aide-de-camp-sqlite/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["Andrey Snow <andoriyu@gmail.com>"]
 
 [dependencies]
 aide-de-camp = { path = "../aide-de-camp", version = "0.1.1", features = ["runner"] }
-sqlx = {version = "0.5.13", default-features = false , features = ["sqlite", "macros", "chrono", "offline"]}
+sqlx = {version = "0.6.2", default-features = false , features = ["sqlite", "macros", "chrono", "offline"]}
 bincode = "2.0.0-rc.1"
 tracing = "0.1.30"
 async-trait = "0.1.52"

--- a/aide-de-camp-sqlite/sqlx-data.json
+++ b/aide-de-camp-sqlite/sqlx-data.json
@@ -1,23 +1,5 @@
 {
   "db": "SQLite",
-  "0206dcb0b25c0beaddb8b169da7f60a5301275d19d82fe7e1ff2f91f90b9b567": {
-    "describe": {
-      "columns": [
-        {
-          "name": "jid",
-          "ordinal": 0,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        true
-      ],
-      "parameters": {
-        "Right": 0
-      }
-    },
-    "query": "SELECT jid FROM adc_queue"
-  },
   "2da89a793016c67949a2a228ffebd70a6dd315b20a35787598ac2c10ba78181e": {
     "describe": {
       "columns": [],
@@ -47,6 +29,76 @@
       }
     },
     "query": "DELETE FROM adc_queue where jid = ?1"
+  },
+  "7621f919fc2f38bb65606230b43156f609d9a6b625d97ad32c2e0bc6aba7005b": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "DELETE FROM adc_queue WHERE started_at IS NULL and jid = ?"
+  },
+  "7ef27bc8cc8b9c6da438cea4f9a5f1f2afdabab54de3a31fdfc3289f62da7205": {
+    "describe": {
+      "columns": [
+        {
+          "name": "jid",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "queue",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "job_type",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "payload",
+          "ordinal": 3,
+          "type_info": "Blob"
+        },
+        {
+          "name": "retries",
+          "ordinal": 4,
+          "type_info": "Int64"
+        },
+        {
+          "name": "scheduled_at",
+          "ordinal": 5,
+          "type_info": "Int64"
+        },
+        {
+          "name": "started_at",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "enqueued_at",
+          "ordinal": 7,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "DELETE FROM adc_queue WHERE started_at IS NULL and jid = ? AND job_type = ? RETURNING *"
   },
   "90ff02e75816b440adb7fcf15d39a89892f021c6ab1d5c54fc582514ee00e3ee": {
     "describe": {

--- a/aide-de-camp-sqlite/src/types.rs
+++ b/aide-de-camp-sqlite/src/types.rs
@@ -22,7 +22,7 @@ impl<'r> FromRow<'r, SqliteRow> for JobRow {
         let job_type = row.try_get("job_type")?;
         let payload = row.try_get::<Vec<u8>, _>("payload").map(Bytes::from)?;
         // Retry count is incremented every time job is checked out from the queue.
-        // We decrement it by one  to "real" retry count.
+        // We decrement it by one to “real” retry count.
         let retries: u32 = row.try_get("retries").map(|r: u32| r - 1)?;
         let scheduled_at = row.try_get("scheduled_at")?;
         let enqueued_at = row.try_get("enqueued_at")?;

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1665507838,
-        "narHash": "sha256-Qw2//QUHSK6H9TKyzKmaMcE0Utn0bUFP9pWHgUlSjaA=",
+        "lastModified": 1665770882,
+        "narHash": "sha256-5uPmZ5i9Ev81QS6Qt9CRYxjhjkfhboLtZjSA4kDdnAg=",
         "owner": "andoriyu",
         "repo": "flakes",
-        "rev": "c02077b0352a988483ce90a06158ba25438d7df5",
+        "rev": "be3a1e82592f806d95ce281e1c777a6777f4e112",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1665297252,
-        "narHash": "sha256-QUpr7W1u8fn7PxsTHQEat4RZJlby5yD9CNZLVV5o4BE=",
+        "lastModified": 1665730515,
+        "narHash": "sha256-0AwNgYCcGr9tae2wD3Bk3YYzG1lQZpoGkU4b1+rMg8U=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "04f2dddc892178a8e20ae9968fe9fbf7775b34fc",
+        "rev": "c6115bd02868c895114cb0e8348166d9ffc08695",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1665470981,
-        "narHash": "sha256-ybKBuDqIq4ZDa1QQqkDVDYewUuxPGs3akEWuhEF2ltw=",
+        "lastModified": 1665815894,
+        "narHash": "sha256-Vboo1L4NMGLKZKVLnOPi9OHlae7uoNyfgvyIUm+SVXE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "0ba1e28f8810df02d9cd20e05b1957a782c7d9d1",
+        "rev": "2348450241a5f945f0ba07e44ecbfac2f541d7f4",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1665349835,
-        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "lastModified": 1665732960,
+        "narHash": "sha256-WBZ+uSHKFyjvd0w4inbm0cNExYTn8lpYFcHEes8tmec=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "rev": "4428e23312933a196724da2df7ab78eb5e67a88e",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1664708386,
-        "narHash": "sha256-aCD8UUGNYb5nYzRmtsq/0yP9gFOQQHr/Lsb5vW+mucw=",
+        "lastModified": 1665584211,
+        "narHash": "sha256-Qc9zn43UjLpP823BP416hAsoaXugwWw+nKPVqsNhqdY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2e4a708918e14fdbd534cc94aaa9470cd19b2464",
+        "rev": "94b0f300dd9a23d4e851aa2a947a1511d3410e2d",
         "type": "github"
       },
       "original": {
@@ -206,11 +206,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1665395272,
-        "narHash": "sha256-kkV5gfDJWMxKmYq3Y2pgvD7zH/I3WoW/0wr659Stj1Q=",
+        "lastModified": 1665584211,
+        "narHash": "sha256-Qc9zn43UjLpP823BP416hAsoaXugwWw+nKPVqsNhqdY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "11aff801aa0ea1fb02ae43e61f7cdf610f5fe2e5",
+        "rev": "94b0f300dd9a23d4e851aa2a947a1511d3410e2d",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1665247575,
-        "narHash": "sha256-Ssoxr1ggoPsvFBsCWNQTleYLOTqx6hFKFvktzGDC51A=",
+        "lastModified": 1665513931,
+        "narHash": "sha256-/jQr/q0Klpm0qkCohUvEHFtH8bEv+C/iY2U5fX6pg58=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "61504c8d951c566eb03037dcb300c96f4bd9a8b6",
+        "rev": "a0ab61fb6c1b0fa2bdcd10cdba17b444941c073e",
         "type": "github"
       },
       "original": {
@@ -249,11 +249,11 @@
     "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1665438197,
-        "narHash": "sha256-uVkoQqUHyeu1j3DucZDmp0w89WaY91eP/p2BmPFIPaY=",
+        "lastModified": 1665765556,
+        "narHash": "sha256-w9L5j0TIB5ay4aRwzGCp8mgvGsu5dVJQvbEFutwr6xE=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5d4995191326a3710206d152a710470e196e4466",
+        "rev": "018b8429cf3fa9d8aed916704e41dfedeb0f4f78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Add support for canceling jobs by ID. Includes "cancel any job by id" and "cancel a specific job type and give me payload back" methods.

Closes #6

BREAKING CHANGE: Changes Queue trait to include new methods
