### PR TITLE
feat: Add support for graceful shutdown

### DIFF
--- a/aide-de-camp-sqlite-bench/src/main.rs
+++ b/aide-de-camp-sqlite-bench/src/main.rs
@@ -1,7 +1,8 @@
 use aide_de_camp::core::job_processor::{JobError, JobProcessor};
 use aide_de_camp::core::queue::Queue;
-use aide_de_camp::core::Xid;
+use aide_de_camp::core::{CancellationToken, Xid};
 use aide_de_camp::core::{Duration, Utc};
+use aide_de_camp::prelude::RunnerOptions;
 use aide_de_camp::runner::job_router::RunnerRouter;
 use aide_de_camp::runner::job_runner::JobRunner;
 use aide_de_camp_sqlite::queue::SqliteQueue;
@@ -46,7 +47,12 @@ impl JobProcessor for BenchJob {
     type Payload = BenchJobPayload;
     type Error = JobError;
 
-    async fn handle(&self, jid: Xid, payload: Self::Payload) -> Result<(), Self::Error> {
+    async fn handle(
+        &self,
+        jid: Xid,
+        payload: Self::Payload,
+        _cancellation_token: CancellationToken,
+    ) -> Result<(), Self::Error> {
         let _count = self.count.fetch_add(1, Ordering::SeqCst);
         let duration_millis = Utc::now().timestamp_millis() - payload.started_at_millis;
         self.tx
@@ -125,7 +131,8 @@ async fn main() {
 
     let started = Instant::now();
     let _runner = {
-        let mut runner = JobRunner::new(queue.clone(), router, concurrency);
+        let mut runner =
+            JobRunner::new(queue.clone(), router, concurrency, RunnerOptions::default());
         tokio::spawn(async move {
             if let Err(e) = runner.run(Duration::milliseconds(1)).await {
                 eprintln!("Runner crashed: {}", e);

--- a/aide-de-camp-sqlite/README.md
+++ b/aide-de-camp-sqlite/README.md
@@ -52,7 +52,7 @@ Crate includes [SQLx `MIGRATOR`](https://docs.rs/sqlx/0.4.0-beta.1/sqlx/macro.mi
 ```rust
 
 use aide_de_camp_sqlite::{SqliteQueue, MIGRATOR};
-use aide_de_camp::prelude::{Queue, JobProcessor, JobRunner, RunnerRouter, Duration, Xid};
+use aide_de_camp::prelude::{Queue, JobProcessor, JobRunner, RunnerOptions, RunnerRouter, Duration, Xid, CancellationToken};
 use async_trait::async_trait;
 use sqlx::SqlitePool;
 
@@ -63,7 +63,7 @@ impl JobProcessor for MyJob {
     type Payload = Vec<u32>;
     type Error = anyhow::Error;
 
-    async fn handle(&self, jid: Xid, payload: Self::Payload) -> Result<(), Self::Error> {
+    async fn handle(&self, jid: Xid, payload: Self::Payload, cancellation_token: CancellationToken) -> Result<(), Self::Error> {
         // Do work here
         Ok(())
     }
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let queue = SqliteQueue::with_pool(pool);
 
     // Add job the queue to run next
-    let _jid = queue.schedule::<MyJob>(vec![1,2,3]).await?;
+    let _jid = queue.schedule::<MyJob>(vec![1,2,3], 0).await?;
 
     // First create a job processor and router
     let router = {
@@ -91,9 +91,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         r
     };
     // Setup runner to at most 10 jobs concurrently
-    let mut runner = JobRunner::new(queue, router, 10);
+    let mut runner = JobRunner::new(queue, router, 10, RunnerOptions::default());
     // Poll the queue every second, this will block unless something went really wrong.
-    // runner.run(Duration::seconds(1)).await?; // Commented to avoid endlessly blocking this doctest.
+    // The future supplied as the second parameter will tell the server to shut down when it completes.
+    runner.run_with_shutdown(Duration::seconds(1), async move {
+        // To avoid blocking this doctest, run for 10 milliseconds, then initiate shutdown.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // In a real application, you may want to wait for a CTRL+C event or something similar.
+        // You could do this with tokio using the signal module: tokio::signal::ctrl_c().await.expect("failed to install CTRL+C signal handler");
+    }).await?;
     Ok(())
 }
 ```

--- a/aide-de-camp-sqlite/src/lib.rs
+++ b/aide-de-camp-sqlite/src/lib.rs
@@ -16,7 +16,7 @@ mod test {
     use aide_de_camp::core::job_handle::JobHandle;
     use aide_de_camp::core::job_processor::JobProcessor;
     use aide_de_camp::core::queue::Queue;
-    use aide_de_camp::core::{Duration, Xid};
+    use aide_de_camp::core::{CancellationToken, Duration, Xid};
     use aide_de_camp::prelude::QueueError;
     use async_trait::async_trait;
     use sqlx::types::chrono::Utc;
@@ -59,7 +59,12 @@ mod test {
         type Payload = TestPayload1;
         type Error = Infallible;
 
-        async fn handle(&self, _jid: Xid, _payload: Self::Payload) -> Result<(), Self::Error> {
+        async fn handle(
+            &self,
+            _jid: Xid,
+            _payload: Self::Payload,
+            _cancellation_token: CancellationToken,
+        ) -> Result<(), Self::Error> {
             Ok(())
         }
 
@@ -95,7 +100,12 @@ mod test {
         type Payload = TestPayload2;
         type Error = Infallible;
 
-        async fn handle(&self, _jid: Xid, _payload: Self::Payload) -> Result<(), Self::Error> {
+        async fn handle(
+            &self,
+            _jid: Xid,
+            _payload: Self::Payload,
+            _cancellation_token: CancellationToken,
+        ) -> Result<(), Self::Error> {
             Ok(())
         }
 
@@ -115,7 +125,12 @@ mod test {
         type Payload = TestPayload2;
         type Error = Infallible;
 
-        async fn handle(&self, _jid: Xid, _payload: Self::Payload) -> Result<(), Self::Error> {
+        async fn handle(
+            &self,
+            _jid: Xid,
+            _payload: Self::Payload,
+            _cancellation_token: CancellationToken,
+        ) -> Result<(), Self::Error> {
             Ok(())
         }
 

--- a/aide-de-camp/Cargo.toml
+++ b/aide-de-camp/Cargo.toml
@@ -18,15 +18,17 @@ async-trait = "0.1.52"
 bincode = { version = "2.0.0-rc.1" }
 bytes = "1.1.0"
 chrono = "0.4"
+futures = "0.3.25"
 rand = { version = "0.8.5", optional = true }
 thiserror = "1.0.30"
 tokio = { version = "1", features = ["time", "sync"] }
+tokio-util = "0.7.4"
 tracing = "0.1.30"
 xid = "1.0.0"
 
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = ["runner"]

--- a/aide-de-camp/src/core.rs
+++ b/aide-de-camp/src/core.rs
@@ -11,6 +11,7 @@ pub type DateTime = chrono::DateTime<chrono::Utc>;
 pub use bincode;
 pub use bytes::Bytes;
 pub use chrono::{Duration, Utc};
+pub use tokio_util::sync::CancellationToken;
 
 pub mod job_handle;
 pub mod job_processor;

--- a/aide-de-camp/src/core/job_processor.rs
+++ b/aide-de-camp/src/core/job_processor.rs
@@ -2,15 +2,24 @@ use crate::core::Xid;
 use async_trait::async_trait;
 use std::convert::Infallible;
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
 
 /// A job-handler interface. Your Payload should implement `bincode::{Decode, Encode}` if you're
 /// planning to use it with the runner and Queue from this crate.
 ///
 /// ## Example
 /// ```rust
-/// use aide_de_camp::prelude::{JobProcessor, Encode, Decode, Xid};
+/// use aide_de_camp::prelude::{JobProcessor, Encode, Decode, Xid, CancellationToken};
 /// use async_trait::async_trait;
 /// struct MyJob;
+///
+/// impl MyJob {
+///     async fn do_work(&self) -> anyhow::Result<()> {
+///         // ..do some work
+///         Ok(())
+///     }
+/// }
+///
 /// #[derive(Encode, Decode)]
 /// struct MyJobPayload(u8, String);
 ///
@@ -23,9 +32,11 @@ use thiserror::Error;
 ///         "my_job"
 ///     }
 ///
-///     async fn handle(&self, jid: Xid, payload: Self::Payload) -> Result<(), Self::Error> {
-///         // ..do work
-///         Ok(())
+///     async fn handle(&self, jid: Xid, payload: Self::Payload, cancellation_token: CancellationToken) -> Result<(), Self::Error> {
+///         tokio::select! {
+///             result = self.do_work() => { result }
+///             _ = cancellation_token.cancelled() => { Ok(()) }
+///         }
 ///     }
 /// }
 /// ```
@@ -39,11 +50,22 @@ pub trait JobProcessor: Send + Sync {
     /// What error is returned
     type Error: Send;
     /// Run the job, passing payload to it. Your payload should implement `bincode::Decode`.
-    async fn handle(&self, jid: Xid, payload: Self::Payload) -> Result<(), Self::Error>;
+    /// You should listen for the `cancellation_token.cancelled()` event in order to handle shutdown requests gracefully.
+    async fn handle(
+        &self,
+        jid: Xid,
+        payload: Self::Payload,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), Self::Error>;
 
     /// How many times job should be retried before being moved to dead queue
     fn max_retries(&self) -> u32 {
         0
+    }
+
+    /// How long to wait before forcefully terminating the job when the server receives a shutdown request.
+    fn shutdown_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(1)
     }
 
     /// Job type, used to differentiate between different jobs in the queue.
@@ -61,6 +83,9 @@ pub enum JobError {
         #[from]
         source: bincode::error::DecodeError,
     },
+
+    #[error("Job failed to complete within the shutdown timeout of {0:#?}")]
+    ShutdownTimeout(std::time::Duration),
 
     /// Error originated in inner-job implementation
     #[error(transparent)]

--- a/aide-de-camp/src/lib.rs
+++ b/aide-de-camp/src/lib.rs
@@ -16,10 +16,12 @@ pub mod prelude {
         job_handle::JobHandle,
         job_processor::{JobError, JobProcessor},
         queue::{Queue, QueueError},
-        Duration, Xid,
+        CancellationToken, Duration, Xid,
     };
     #[cfg(feature = "runner")]
-    pub use super::runner::{job_router::RunnerRouter, job_runner::JobRunner};
+    pub use super::runner::{
+        job_router::RunnerRouter, job_runner::JobRunner, job_runner::RunnerOptions,
+    };
     pub use bincode::{Decode, Encode};
 }
 

--- a/aide-de-camp/src/runner/job_router.rs
+++ b/aide-de-camp/src/runner/job_router.rs
@@ -6,6 +6,7 @@ use bincode::{self, Decode, Encode};
 use chrono::Duration;
 use std::collections::HashMap;
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 /// A job processor router. Matches job type to job processor implementation.
@@ -13,9 +14,17 @@ use tracing::instrument;
 ///
 /// ## Example
 /// ```rust
-/// use aide_de_camp::prelude::{JobProcessor, RunnerRouter, Encode, Decode, Xid};
+/// use aide_de_camp::prelude::{JobProcessor, RunnerRouter, Encode, Decode, Xid, CancellationToken};
 /// use async_trait::async_trait;
 /// struct MyJob;
+///
+/// impl MyJob {
+///     async fn do_work(&self) -> anyhow::Result<()> {
+///         // ..do some work
+///         Ok(())
+///     }
+/// }
+///
 /// #[derive(Encode, Decode)]
 /// struct MyJobPayload(u8, String);
 ///
@@ -28,9 +37,11 @@ use tracing::instrument;
 ///         "my_job"
 ///     }
 ///
-///     async fn handle(&self, jid: Xid, payload: Self::Payload) -> Result<(), Self::Error> {
-///         // ..do work
-///         Ok(())
+///     async fn handle(&self, jid: Xid, payload: Self::Payload, cancellation_token: CancellationToken) -> Result<(), Self::Error> {
+///         tokio::select! {
+///             result = self.do_work() => { result }
+///             _ = cancellation_token.cancelled() => { Ok(()) }
+///         }
 ///     }
 /// }
 ///
@@ -67,29 +78,29 @@ impl RunnerRouter {
     /// own job runner, then this is what you should use to process job that is already pulled
     /// from the queue. In all other cases, you shouldn't use this function directly.
     #[instrument(skip_all, err, fields(job_type = %job_handle.job_type(), jid = %job_handle.id().to_string(), retries = job_handle.retries()))]
-    pub async fn process<H: JobHandle>(&self, job_handle: H) -> Result<(), RunnerError> {
+    pub async fn process<H: JobHandle>(
+        &self,
+        job_handle: H,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), RunnerError> {
         if let Some(r) = self.jobs.get(job_handle.job_type()) {
-            match r
-                .handle(job_handle.id(), job_handle.payload())
-                .await
-                .map_err(JobError::from)
-            {
-                Ok(_) => {
-                    job_handle.complete().await?;
-                    Ok(())
+            let job_shutdown_timeout = r.shutdown_timeout();
+
+            let job_result = tokio::select! {
+                job_result = r.handle(job_handle.id(), job_handle.payload(), cancellation_token.child_token()) => {
+                    job_result
                 }
-                Err(e) => {
-                    tracing::error!("Error during job processing: {}", e);
-                    if job_handle.retries() >= r.max_retries() {
-                        tracing::warn!("Moving job {} to dead queue", job_handle.id().to_string());
-                        job_handle.dead_queue().await?;
-                        Ok(())
-                    } else {
-                        job_handle.fail().await?;
-                        Ok(())
-                    }
+                cancellation_result = cancellation_handler(job_shutdown_timeout, cancellation_token.child_token()) => {
+                    cancellation_result
                 }
-            }
+            };
+            handle_job_result(
+                job_result,
+                job_handle,
+                r.max_retries(),
+                cancellation_token.child_token(),
+            )
+            .await
         } else {
             Err(RunnerError::UnknownJobType(
                 job_handle.job_type().to_string(),
@@ -100,24 +111,50 @@ impl RunnerRouter {
     /// In a loop, poll the queue with interval (passes interval to `Queue::next`) and process
     /// incoming jobs. Function process jobs one-by-one without job-level concurrency. If you need
     /// concurrency, look at the `JobRunner` instead.
-    pub async fn listen<Q, QR>(&self, queue: Q, poll_interval: Duration)
-    where
+    pub async fn listen<Q, QR>(
+        &self,
+        queue: Q,
+        poll_interval: Duration,
+        cancellation_token: CancellationToken,
+    ) where
         Q: AsRef<QR>,
         QR: Queue,
     {
         let job_types = self.types();
         loop {
-            match queue.as_ref().next(&job_types, poll_interval).await {
-                Ok(handle) => match self.process(handle).await {
+            tokio::select! {
+                next = queue.as_ref().next(&job_types, poll_interval) => {
+                    let cancellation_token = cancellation_token.child_token();
+                    self.handle_next_job::<QR>(next, cancellation_token).await;
+                }
+                _ = cancellation_token.cancelled() => {
+                    // If cancellation is requested while a job is processing, this block will execute on the next iteration.
+                    tracing::debug!("Shutdown request received, stopping listener");
+                    return
+                }
+            }
+        }
+    }
+
+    async fn handle_next_job<QR>(
+        &self,
+        next: Result<QR::JobHandle, QueueError>,
+        cancellation_token: CancellationToken,
+    ) where
+        QR: Queue,
+    {
+        match next {
+            Ok(handle) => {
+                match self.process(handle, cancellation_token.child_token()).await {
                     Ok(_) => {}
                     Err(RunnerError::QueueError(e)) => handle_queue_error(e).await,
                     Err(RunnerError::UnknownJobType(name)) => {
                         tracing::error!("Unknown job type: {}", name)
                     }
-                },
-                Err(e) => {
-                    handle_queue_error(e).await;
-                }
+                };
+            }
+            Err(e) => {
+                handle_queue_error(e).await;
             }
         }
     }
@@ -130,6 +167,45 @@ pub enum RunnerError {
     UnknownJobType(String),
     #[error(transparent)]
     QueueError(#[from] QueueError),
+}
+
+async fn cancellation_handler(
+    job_shutdown_timeout: std::time::Duration,
+    cancellation_token: CancellationToken,
+) -> Result<(), JobError> {
+    cancellation_token.cancelled().await;
+    // Wait for the duration of the shutdown timeout specified by the job configuration.
+    // The job should complete within the timeout period, preventing this method from completing.
+    tokio::time::sleep(job_shutdown_timeout).await;
+    Err(JobError::ShutdownTimeout(job_shutdown_timeout))
+}
+
+async fn handle_job_result<H: JobHandle>(
+    job_result: Result<(), JobError>,
+    job_handle: H,
+    max_retries: u32,
+    cancellation_token: CancellationToken,
+) -> Result<(), RunnerError> {
+    if cancellation_token.is_cancelled() {
+        tracing::info!("Cancellation was requested during job processing");
+    }
+    match job_result.map_err(JobError::from) {
+        Ok(_) => {
+            job_handle.complete().await?;
+            Ok(())
+        }
+        Err(e) => {
+            tracing::error!("Error during job processing: {}", e);
+            if job_handle.retries() >= max_retries {
+                tracing::warn!("Moving job {} to dead queue", job_handle.id().to_string());
+                job_handle.dead_queue().await?;
+                Ok(())
+            } else {
+                job_handle.fail().await?;
+                Ok(())
+            }
+        }
+    }
 }
 
 async fn handle_queue_error(error: QueueError) {
@@ -154,7 +230,12 @@ mod test {
             type Payload = Vec<i32>;
             type Error = Infallible;
 
-            async fn handle(&self, _jid: Xid, _payload: Self::Payload) -> Result<(), Infallible> {
+            async fn handle(
+                &self,
+                _jid: Xid,
+                _payload: Self::Payload,
+                _cancellation_token: CancellationToken,
+            ) -> Result<(), Infallible> {
                 dbg!("we did it patrick");
                 Ok(())
             }
@@ -167,12 +248,17 @@ mod test {
 
         let job: Box<dyn JobProcessor<Payload = _, Error = _>> = Box::new(Example);
 
-        job.handle(xid::new(), payload.clone()).await.unwrap();
+        job.handle(xid::new(), payload.clone(), CancellationToken::new())
+            .await
+            .unwrap();
         let wrapped: Box<dyn JobProcessor<Payload = _, Error = JobError>> =
             Box::new(WrappedJobHandler::new(Example));
 
         let payload = bincode::encode_to_vec(&payload, standard()).unwrap();
 
-        wrapped.handle(xid::new(), payload.into()).await.unwrap();
+        wrapped
+            .handle(xid::new(), payload.into(), CancellationToken::new())
+            .await
+            .unwrap();
     }
 }

--- a/aide-de-camp/src/runner/job_runner.rs
+++ b/aide-de-camp/src/runner/job_runner.rs
@@ -1,11 +1,38 @@
 use super::job_router::RunnerRouter;
 use crate::core::queue::{Queue, QueueError};
 use anyhow::Context;
+use futures::{future::join_all, stream::FuturesUnordered};
 use rand::seq::SliceRandom;
-use std::sync::Arc;
-use tokio::sync::Semaphore;
+use std::{
+    future::{self, Future},
+    sync::Arc,
+};
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
 
 pub const JITTER_INTERVAL_MS: [i64; 10] = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34];
+
+/// Options for configuring the runner
+#[non_exhaustive]
+pub struct RunnerOptions {
+    /// How long to wait for all workers to shut down gracefully when system shutdown is requested.
+    /// This timeout will only be hit if the job timeout is set higher than this or if some part of the system is stuck.
+    ///
+    /// This should be set higher than the job timeout in order to ensure all jobs are properly cleaned up.
+    /// The default value is 15 seconds.
+    pub worker_shutdown_timeout: std::time::Duration,
+}
+
+impl Default for RunnerOptions {
+    fn default() -> Self {
+        Self {
+            worker_shutdown_timeout: std::time::Duration::from_secs(15),
+        }
+    }
+}
 
 /// A bridge between job processors and the queue.
 ///
@@ -30,6 +57,7 @@ where
     queue: Arc<Q>,
     processor: Arc<RunnerRouter>,
     semaphore: Arc<Semaphore>,
+    options: RunnerOptions,
 }
 
 impl<Q> JobRunner<Q>
@@ -37,11 +65,17 @@ where
     Q: Queue + 'static,
 {
     /// Create a new JobRunner with desired concurrency from queue and router.
-    pub fn new(queue: Q, processor: RunnerRouter, concurrency: usize) -> Self {
+    pub fn new(
+        queue: Q,
+        processor: RunnerRouter,
+        concurrency: usize,
+        options: RunnerOptions,
+    ) -> Self {
         Self {
             queue: Arc::new(queue),
             processor: Arc::new(processor),
             semaphore: Arc::new(Semaphore::new(concurrency)),
+            options,
         }
     }
 }
@@ -50,25 +84,76 @@ impl<Q> JobRunner<Q>
 where
     Q: Queue + 'static,
 {
-    /// This function runs forever unless built-in Semaphore gets closed. Which never happens.
-    /// Later there might be a way to stop it.
+    /// Run the job runner with the desired polling interval. This method blocks forever.
     pub async fn run(&mut self, interval: chrono::Duration) -> Result<(), QueueError> {
+        // Pass in a future that never completes to the shutdown handler so the server can run until program termination
+        self.run_with_shutdown(interval, future::pending()).await
+    }
+
+    /// Run the job runner with the desired polling interval.
+    /// This method blocks until the provided shutdown future completes.
+    pub async fn run_with_shutdown<F: Future<Output = ()>>(
+        &mut self,
+        interval: chrono::Duration,
+        shutdown: F,
+    ) -> Result<(), QueueError> {
+        let worker_handles = FuturesUnordered::new();
+        let cancellation_token = CancellationToken::new();
+        let mut shutdown = Box::pin(shutdown);
         loop {
             let semaphore = self.semaphore.clone();
-            let permit = semaphore
-                .acquire_owned()
-                .await
-                .context("Semaphore closed while running")?;
-            let queue = self.queue.clone();
-            let processor = self.processor.clone();
-            tokio::spawn(async move {
-                let _permit = permit;
-                let queue = queue;
-                let processor = processor;
-                let interval = interval + get_random_jitter();
-                processor.listen(queue, interval).await;
-            });
+            tokio::select! {
+                permit = semaphore.acquire_owned() => {
+                    let permit = permit.context("Semaphore closed while running")?;
+                    let worker_handle = self.spawn_worker(permit, interval, cancellation_token.child_token());
+                    worker_handles.push(worker_handle);
+                }
+                _ = &mut shutdown => {
+                    handle_shutdown(self.options.worker_shutdown_timeout, worker_handles, cancellation_token).await;
+                    return Ok(());
+                }
+            }
         }
+    }
+
+    fn spawn_worker(
+        &self,
+        permit: OwnedSemaphorePermit,
+        interval: chrono::Duration,
+        cancellation_token: CancellationToken,
+    ) -> JoinHandle<()> {
+        let queue = self.queue.clone();
+        let processor = self.processor.clone();
+        let cancellation_token = cancellation_token.child_token();
+
+        tokio::spawn(async move {
+            let _permit = permit;
+            let interval = interval + get_random_jitter();
+            processor.listen(queue, interval, cancellation_token).await;
+        })
+    }
+}
+
+async fn handle_shutdown(
+    worker_shutdown_timeout: std::time::Duration,
+    worker_handles: FuturesUnordered<JoinHandle<()>>,
+    cancellation_token: CancellationToken,
+) {
+    tracing::debug!("Received shutdown request, attempting graceful shutdown");
+    cancellation_token.cancel();
+    match tokio::time::timeout(worker_shutdown_timeout, join_all(worker_handles)).await {
+        Ok(worker_results) => {
+            for result in worker_results {
+                if let Err(e) = result {
+                    tracing::error!("Worker panicked: {e:?}");
+                }
+            }
+            tracing::debug!("All workers have shut down");
+        }
+        Err(_) => tracing::warn!(
+            "One or more workers failed to shut down within the grace period of {:#?}",
+            worker_shutdown_timeout
+        ),
     }
 }
 
@@ -77,4 +162,294 @@ fn get_random_jitter() -> chrono::Duration {
         .choose(&mut rand::thread_rng())
         .map(|ms| chrono::Duration::milliseconds(*ms))
         .unwrap_or_else(|| chrono::Duration::milliseconds(5)) // Always takes a happy path technically
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::*;
+    use crate::prelude::*;
+    use async_trait::async_trait;
+    use futures::Future;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    #[derive(Default, Clone)]
+    struct TestHandle {
+        completed: Arc<AtomicBool>,
+        failed: Arc<AtomicBool>,
+        dead_queue: Arc<AtomicBool>,
+        complete_delay: std::time::Duration,
+    }
+
+    #[async_trait]
+    impl JobHandle for TestHandle {
+        fn id(&self) -> Xid {
+            xid::new()
+        }
+
+        fn job_type(&self) -> &str {
+            "test"
+        }
+
+        fn payload(&self) -> Bytes {
+            Bytes::new()
+        }
+
+        fn retries(&self) -> u32 {
+            0
+        }
+
+        async fn complete(mut self) -> Result<(), QueueError> {
+            tokio::time::sleep(self.complete_delay).await;
+            self.completed.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn fail(mut self) -> Result<(), QueueError> {
+            self.failed.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn dead_queue(mut self) -> Result<(), QueueError> {
+            self.dead_queue.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct TestQueue {
+        test_handle: Option<TestHandle>,
+    }
+
+    #[async_trait]
+    impl Queue for TestQueue {
+        type JobHandle = TestHandle;
+
+        async fn schedule_at<J>(
+            &self,
+            _payload: J::Payload,
+            _scheduled_at: DateTime,
+            _priority: i8,
+        ) -> Result<Xid, QueueError>
+        where
+            J: JobProcessor + 'static,
+            J::Payload: Encode,
+        {
+            Ok(xid::new())
+        }
+
+        async fn poll_next_with_instant(
+            &self,
+            _job_types: &[&str],
+            _now: DateTime,
+        ) -> Result<Option<Self::JobHandle>, QueueError> {
+            Ok(self.test_handle.clone())
+        }
+
+        async fn cancel_job(&self, _job_id: Xid) -> Result<(), QueueError> {
+            Ok(())
+        }
+
+        async fn unschedule_job<J>(&self, job_id: Xid) -> Result<J::Payload, QueueError>
+        where
+            J: JobProcessor + 'static,
+            J::Payload: Decode,
+        {
+            match &self.test_handle {
+                Some(handle) => {
+                    let payload = handle.payload();
+                    let (decoded, _) =
+                        bincode::decode_from_slice(&payload, bincode::config::standard())?;
+                    Ok(decoded)
+                }
+                None => Err(QueueError::JobNotFound(job_id)),
+            }
+        }
+    }
+
+    struct TestJobProcessor {
+        running: Arc<AtomicBool>,
+        started_tx: tokio::sync::broadcast::Sender<()>,
+        sleep_time: std::time::Duration,
+        handle_shutdown: bool,
+    }
+
+    impl Default for TestJobProcessor {
+        fn default() -> Self {
+            let (started_tx, _) = tokio::sync::broadcast::channel(1);
+            Self {
+                started_tx,
+                running: Default::default(),
+                sleep_time: Default::default(),
+                handle_shutdown: Default::default(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl JobProcessor for TestJobProcessor {
+        type Payload = ();
+        type Error = anyhow::Error;
+
+        async fn handle(
+            &self,
+            _jid: Xid,
+            _payload: Self::Payload,
+            cancellation_token: CancellationToken,
+        ) -> Result<(), Self::Error> {
+            self.running.store(true, Ordering::SeqCst);
+            self.started_tx.send(()).unwrap();
+
+            tokio::select! {
+                _ = tokio::time::sleep(self.sleep_time) => {}
+                _ = cancellation_token.cancelled(), if self.handle_shutdown => {}
+            };
+
+            self.running.store(false, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn name() -> &'static str {
+            "test"
+        }
+
+        fn shutdown_timeout(&self) -> std::time::Duration {
+            std::time::Duration::from_millis(10)
+        }
+    }
+
+    async fn start_runner<F: Future<Output = ()> + Send + 'static>(
+        mut runner: JobRunner<TestQueue>,
+        shutdown: F,
+    ) {
+        let handle = tokio::spawn(async move {
+            runner
+                .run_with_shutdown(chrono::Duration::milliseconds(1), shutdown)
+                .await
+                .unwrap();
+        });
+
+        // Force the server to shut down after a few seconds to prevent the test from hanging
+        // if there's a bug in the code that causes the shutdown to fail
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    async fn shutdown_on_job_start(
+        processor: TestJobProcessor,
+        handle: TestHandle,
+        options: RunnerOptions,
+    ) {
+        let mut router = RunnerRouter::default();
+        let mut started_rx = processor.started_tx.subscribe();
+        router.add_job_handler(processor);
+        let queue = TestQueue {
+            test_handle: Some(handle),
+        };
+        let runner = JobRunner::new(queue, router, 1, options);
+
+        start_runner(runner, async move {
+            // Initiate shutdown as soon as a job is started
+            started_rx.recv().await.unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn handles_shutdown_with_no_jobs() {
+        let runner = JobRunner::new(
+            TestQueue::default(),
+            RunnerRouter::default(),
+            1,
+            RunnerOptions::default(),
+        );
+
+        start_runner(runner, async move {
+            // Give it a few milliseconds to ensure everything starts, then initiate shutdown
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn shuts_down_forcefully_on_stuck_job() {
+        let running = Arc::new(AtomicBool::new(false));
+
+        // Job will run for 30 seconds without listening for cancellation
+        let processor = TestJobProcessor {
+            running: running.clone(),
+            sleep_time: std::time::Duration::from_secs(30),
+            handle_shutdown: false,
+            ..Default::default()
+        };
+
+        let handle = TestHandle::default();
+        let dead_queue = handle.dead_queue.clone();
+
+        shutdown_on_job_start(processor, handle, RunnerOptions::default()).await;
+
+        // Job should not have completed after shutdown completes
+        assert!(running.load(Ordering::SeqCst));
+        // Because it did not shut down gracefully, the job should've moved to the dead queue
+        assert!(dead_queue.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn shuts_job_down_gracefully_on_cancel() {
+        let running = Arc::new(AtomicBool::new(false));
+
+        // Job will run for 30 seconds and will listen for cancellation
+        let processor = TestJobProcessor {
+            running: running.clone(),
+            sleep_time: std::time::Duration::from_secs(30),
+            handle_shutdown: true,
+            ..Default::default()
+        };
+
+        let handle = TestHandle::default();
+        let completed = handle.completed.clone();
+
+        shutdown_on_job_start(processor, handle, RunnerOptions::default()).await;
+
+        // Job should've completed on cancel
+        assert!(!running.load(Ordering::SeqCst));
+        // Because it did shut down gracefully, the completion handler should've ran
+        assert!(completed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn shuts_down_gracefully_on_queue_hang() {
+        let running = Arc::new(AtomicBool::new(false));
+
+        let processor = TestJobProcessor {
+            running: running.clone(),
+            handle_shutdown: true,
+            ..Default::default()
+        };
+
+        let handle = TestHandle {
+            // Simulate the queue hanging when the complete method is called
+            complete_delay: std::time::Duration::from_secs(10),
+            ..Default::default()
+        };
+
+        let completed = handle.completed.clone();
+
+        shutdown_on_job_start(
+            processor,
+            handle,
+            RunnerOptions {
+                worker_shutdown_timeout: std::time::Duration::from_millis(10),
+            },
+        )
+        .await;
+
+        // Job should've completed immediately
+        assert!(!running.load(Ordering::SeqCst));
+        // Completion handler should not have ran because the queue should be stuck
+        assert!(!completed.load(Ordering::SeqCst));
+    }
 }


### PR DESCRIPTION
This change adds support for gracefully shutting down the system.

Resolves #15

**New features**:
- Added the `run_with_shutdown` method to `JobProcessor`. This allows the user to supply an arbitrary future that will initiate shutdown on completion. This is designed to mimic the semantics of other libraries such as Tonic and Hyper which use a similar mechanism.
- Added the `RunnerOptions` struct which is supplied as a parameter to `new`
    - Currently, this only has one field - `worker_shutdown_timeout` - specifies how long to wait for graceful shutdown before terminating all workers.
    - This struct implements `Default` and additional optional settings could be added to this in the future. It has `#[non_exhaustive]` so more fields can be added without breaking changes.
    - Added `cancellation_token` to the `JobProcessor`'s handler method, allowing jobs to easily react to shutdown requests.
    - Added the optional `shutdown_timeout` method for the `JobProcessor` interface, specifying how long to give the job to shut down before forcing termination.
    - If a job does not gracefully shut down within the grace period, it will be treated as an error and handled accordingly.

**Considerations**:
- `worker_shutdown_timeout` currently defaults to a rather high number (15 seconds) because ideally it shouldn't be hit unless some other part of the system is stuck. If the job timeout is set to the default (1 second) or something else reasonably small, this should be sufficient to shut down the entire system. However, if someone does set the job timeout to something higher than the default worker timeout and forgets to increase the worker timeout, the handlers to update the job status may not run in time. I left it implemented this way because it was the simplest solution and I don't think having a very long job shutdown period would be a common use case. If we want to prevent this behavior, we could disable the `worker_shutdown_timeout` by default and make it opt-in instead.
- Currently, `chrono::Duration` is used for durations, so the obvious choice would be to continue using `chrono` for consistency. However, the timeouts need to be passed to functions that require the use of `std::time::Duration`. Unfortunately, Converting from `chrono::Duration` to `std::time::Duration` requires the use of `chrono::Duration::to_std` which is a fallible conversion. We would need to either return a `Result` during every conversion or use some default value if the conversion fails. This seemed rather annoying to deal with, so I just stuck with `std::time::Duration`. However, if you do wish to exclusively use `chrono` in the public API, I can change this.
- Since this adds more settings that need to be passed to the `JobProcessor`, maybe it makes sense to create some sensible defaults for `concurrency` and `poll_interval` and add them to `RunnerOptions` instead of making them individual parameters? Not necessary in any way, just a thought.

**Breaking Changes**:
- `cancellation_token` is now a mandatory parameter of `JobProcessor`'s `handle` method.
- `options` is now a mandatory parameter of`JobRunner`'s `new` method.

**Other Notes**:
- Added the missing job priority parameter for the doctest on `aide-de-camp-sqlite/README.md`
- `WrappedJobHandler` did not implement `max_retries`, so it wasn't respecting the setting used by the inner job handler. This is now implemented.
- Added a unit test module for `JobProcessor` in order to test my changes. The test implementations for the queue and job handler added here should be usable for more tests in the future if desired.